### PR TITLE
remove decorators from View

### DIFF
--- a/lib/viewing/RenderableView.js
+++ b/lib/viewing/RenderableView.js
@@ -23,8 +23,6 @@ var RenderableView = _.extendOwn({},
 
         logic: noop,
 
-        decorators: null,
-
         partials: null,
 
         templateAdapter: StringTemplateAdapter,
@@ -135,20 +133,6 @@ var RenderableView = _.extendOwn({},
             this.unrenderedChildViews.length = 0;
         },
 
-        runDecorators: function() {
-            if (!this.decorators) {
-                return;
-            }
-
-            var $el = this.$el;
-
-            for (var i = 0, len = this.decorators.length; i < len; i++) {
-                var decorator = this.decorators[i];
-
-                decorator.decorate($el);
-            }
-        },
-
         render: function() {
             var isReanimatingFromServer = this.isAttached && !this.hasBeenRendered;
 
@@ -175,10 +159,6 @@ var RenderableView = _.extendOwn({},
             this.hasBeenRendered = true;
 
             this.afterRender();
-
-            if (!isReanimatingFromServer) {
-                this.runDecorators();
-            }
 
             if (!isReanimatingFromServer && this.isInDOM) {
                 this.isInDOM = false;

--- a/spec/client/viewing/RenderableViewSpec.js
+++ b/spec/client/viewing/RenderableViewSpec.js
@@ -300,77 +300,6 @@ describe("RenderableView", function() {
 
         });
 
-        describe("when view has decorators", function() {
-            var firstDecorateFunction;
-            var secondDecorateFunction;
-
-            beforeEach(function() {
-                firstDecorateFunction = jasmine.createSpy();
-                secondDecorateFunction = jasmine.createSpy();
-
-                ViewThatRenders = BaseRenderableView.extend({
-                    decorators: [{
-                        decorate: firstDecorateFunction
-                    }, {
-                        decorate: secondDecorateFunction
-                    }]
-                });
-
-                view = new ViewThatRenders();
-
-                spyOn(view, "runDecorators").and.callThrough();
-            });
-
-            it("runs decorators", function() {
-                view.render();
-                expect(view.runDecorators).toHaveBeenCalled();
-            });
-
-            it("calls decorate on each decorator", function() {
-                view.render();
-                expect(firstDecorateFunction).toHaveBeenCalled();
-                expect(secondDecorateFunction).toHaveBeenCalled();
-            });
-
-            it("calls decorate functions with the view's $el", function() {
-                view.render();
-                expect(firstDecorateFunction).toHaveBeenCalledWith(view.$el);
-                expect(secondDecorateFunction).toHaveBeenCalledWith(view.$el);
-            });
-
-            it("runs decorators after afterRender", function() {
-                spyOn(view, "afterRender").and.callFake(function() {
-                    expect(firstDecorateFunction).not.toHaveBeenCalled();
-                    expect(secondDecorateFunction).not.toHaveBeenCalled();
-                });
-                view.render();
-                expect(firstDecorateFunction).toHaveBeenCalled();
-                expect(secondDecorateFunction).toHaveBeenCalled();
-            });
-        });
-
-        describe("when view does NOT have decorators", function() {
-
-            beforeEach(function() {
-                view = new BaseRenderableView();
-                spyOn(view, "runDecorators").and.callThrough();
-            });
-
-            it("runs decorators", function() {
-                view.render();
-                expect(view.runDecorators).toHaveBeenCalled();
-            });
-
-            it("does NOT throw", function() {
-                var renderingWithoutDecorators = function() {
-                    view.render();
-                };
-
-                expect(renderingWithoutDecorators).not.toThrow();
-            });
-
-        });
-
         describe("when has already been attached", function() {
 
             beforeEach(function() {
@@ -694,34 +623,6 @@ describe("RenderableView", function() {
                 expect(view.el.innerHTML).toBe(
                     "hello<div id=\"child1\" data-view-uid=\"null_3\"></div><div id=\"child2\" data-view-uid=\"null_4\"></div>"
                 );
-            });
-
-        });
-
-        describe("when view has decorators", function() {
-
-            beforeEach(function() {
-                ViewThatRenders = BaseRenderableView.extend({
-                    decorators: [{
-                        decorate: jasmine.createSpy()
-                    }, {
-                        decorate: jasmine.createSpy()
-                    }]
-                });
-
-                view = new ViewThatRenders();
-
-                spyOn(view, "runDecorators").and.callThrough();
-
-                view.render();
-
-                expect(view.runDecorators.calls.count()).toBe(1);
-            });
-
-            it("runs decorators again", function() {
-                view.render();
-
-                expect(view.runDecorators.calls.count()).toBe(2);
             });
 
         });


### PR DESCRIPTION
decorators force a parse on the html of a View so they are pretty slow. they can be useful though. their functionality can be replicated by an idempotent function in the View's afterRender.